### PR TITLE
Reveal project with "built by" links

### DIFF
--- a/ParallelBuildDebuggingLogger/Javascript.js
+++ b/ParallelBuildDebuggingLogger/Javascript.js
@@ -21,3 +21,11 @@ function filter() {
         }
     }
 }
+
+function show(id) {
+    var destinationElement = document.getElementById(id);
+
+    destinationElement.style.display = "";
+
+    destinationElement.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" });
+}

--- a/ParallelBuildDebuggingLogger/ProjectBuildInfo.cs
+++ b/ParallelBuildDebuggingLogger/ProjectBuildInfo.cs
@@ -104,7 +104,7 @@ namespace ParallelBuildDebuggingLogger
 
         public string ProjectIdLink
         {
-            get => $"<a href=\"#{ParentProjectInstanceId}\">{ParentProjectInstanceId}</a>";
+            get => $"<a class=\"linktoproject\" onclick=\"show({ParentProjectInstanceId})\">{ParentProjectInstanceId}</a>";
         }
     }
 }

--- a/ParallelBuildDebuggingLogger/Stylesheet.css
+++ b/ParallelBuildDebuggingLogger/Stylesheet.css
@@ -9,6 +9,10 @@ body {
   margin-bottom: 12px;
 }
 
+a.linktoproject {
+  text-decoration-line: underline;
+}
+
 .projectdescription {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Fixes #9 by revealing and then scrolling to the linked project instance.